### PR TITLE
Remove error instance from result.error

### DIFF
--- a/android/src/main/java/com/xendit/fxendit/FxenditPlugin.java
+++ b/android/src/main/java/com/xendit/fxendit/FxenditPlugin.java
@@ -94,7 +94,7 @@ public class FxenditPlugin implements FlutterPlugin, MethodCallHandler, Activity
 
                     @Override
                     public void onError(XenditError error) {
-                        result.error(error.getErrorCode(), error.getErrorMessage(), error);
+                        result.error(error.getErrorCode(), error.getErrorMessage(), null);
                     }
                 });
         }
@@ -119,7 +119,7 @@ public class FxenditPlugin implements FlutterPlugin, MethodCallHandler, Activity
 
                 @Override
                 public void onError(XenditError error) {
-                    result.error(error.getErrorCode(), error.getErrorMessage(), error);
+                    result.error(error.getErrorCode(), error.getErrorMessage(), null);
                 }
             });
         }
@@ -147,7 +147,7 @@ public class FxenditPlugin implements FlutterPlugin, MethodCallHandler, Activity
 
             @Override
             public void onError(XenditError error) {
-                result.error(error.getErrorCode(), error.getErrorMessage(), error);
+                result.error(error.getErrorCode(), error.getErrorMessage(), null);
             }
         });
     }


### PR DESCRIPTION
Fix untuk #7 , sepertinya Flutter tidak bisa men-serialize XenditError, jadi tidak usah dikirim di result.error, dan saya lihat details errornya juga tidak dipakai di bagian dartnya

Untuk yang mengalami error, bisa di coba sementara menggunakan repo saya
```yaml
dependencies:
  fxendit:
    git:
      url: git://github.com/falfox/fxendit.git
```